### PR TITLE
CID-1119 Adding S3 read permission codebuild

### DIFF
--- a/modules/codebuild/main.tf
+++ b/modules/codebuild/main.tf
@@ -189,7 +189,9 @@ data "aws_iam_policy_document" "permissions" {
       "codebuild:BatchPutTestCases",
       "codebuild:BatchPutCodeCoverages",
       "ecr:BatchGetImage",
-      "ecr:DescribeImages"
+      "ecr:DescribeImages",
+      "s3:GetObject",
+      "s3:GetBucketAcl"
     ], var.extra_permissions))
 
     effect = "Allow"


### PR DESCRIPTION
Hi Mike, Don,
We are currently using this public repo for creating codebuilds in LOS project. This PR is for adding S3 read permissions (GetObject and GetBucketAcl) to the Service role created as part of the codebuild module. The service role currently have putobject access. 
This will be helpful for codebuilds which want to fetch objects from S3. Use case is for the new codebuilds which we creating for document classification which will fetch the input files from S3 bucket for training the model.
