### PR TITLE
remove aws_s3_bucket_acl

### DIFF
--- a/modules/codebuild_scaffold/main.tf
+++ b/modules/codebuild_scaffold/main.tf
@@ -24,10 +24,10 @@ resource "aws_s3_bucket_public_access_block" "artifact-store_access" {
   restrict_public_buckets = true
 }
 
-resource "aws_s3_bucket_acl" "artifact-store-acl" {
-  bucket = aws_s3_bucket.artifact-store.id
-  acl    = "private"
-}
+#resource "aws_s3_bucket_acl" "artifact-store-acl" {
+#  bucket = aws_s3_bucket.artifact-store.id
+#  acl    = "private"
+#}
 
 resource "aws_s3_bucket_versioning" "artifact-store-versioning" {
   bucket = aws_s3_bucket.artifact-store.id


### PR DESCRIPTION
All new buckets are created as private by default. Explicitly setting this resource causes TF to error.